### PR TITLE
Alchemy -> Flux, update Hoodoo & bundle

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,13 +5,13 @@
 
 # Fundamental architecture
 
-  # For queue-based operation with Alchemy AMQ, add this
+  # For queue-based operation with Alchemy Flux, add this
   # BETWEEN the Rack and Hoodoo lines:
   #
-  #   gem 'alchemy-amq', '~> 1.0'
+  #   gem 'alchemy-flux', '~> 0.1'
 
   gem 'rack',   '~> 1.5'
-  gem 'hoodoo', '~> 1.0'
+  gem 'hoodoo', '~> 1.1'
 
 # ActiveRecord and PostgreSQL
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,14 +11,14 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.2.5)
-      activesupport (= 4.2.5)
+    activemodel (4.2.5.1)
+      activesupport (= 4.2.5.1)
       builder (~> 3.1)
-    activerecord (4.2.5)
-      activemodel (= 4.2.5)
-      activesupport (= 4.2.5)
+    activerecord (4.2.5.1)
+      activemodel (= 4.2.5.1)
+      activesupport (= 4.2.5.1)
       arel (~> 6.0)
-    activesupport (4.2.5)
+    activesupport (4.2.5.1)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -60,7 +60,7 @@ GEM
       ffi
       guard (~> 2.0)
       spoon
-    hoodoo (1.0.5)
+    hoodoo (1.1.0)
       dalli (~> 2.7)
       kgio (~> 2.9)
       uuidtools (~> 2.1)
@@ -75,11 +75,11 @@ GEM
       rb-inotify (>= 0.9)
     lumberjack (1.0.10)
     method_source (0.8.2)
-    minitest (5.8.3)
+    minitest (5.8.4)
     multi_json (1.11.2)
     multi_xml (0.5.5)
     nenv (0.2.0)
-    newrelic_rpm (3.14.1.311)
+    newrelic_rpm (3.14.2.312)
     notiffany (0.0.8)
       nenv (~> 0.1)
       shellany (~> 0.0)
@@ -151,7 +151,7 @@ DEPENDENCIES
   faker (~> 1.4)
   guard-rspec
   guard-shotgun
-  hoodoo (~> 1.0)
+  hoodoo (~> 1.1)
   newrelic_rpm (~> 3.9)
   pg (~> 0.17)
   pry-byebug


### PR DESCRIPTION
* Change Alchemy AMQ reference to open-source Flux
* Update Hoodoo to support Flux
* Maintenance bundle update