### PR TITLE
Fix 'git' command used to get the current branch name

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,16 +11,15 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.2.7.1)
-      activesupport (= 4.2.7.1)
+    activemodel (4.2.8)
+      activesupport (= 4.2.8)
       builder (~> 3.1)
-    activerecord (4.2.7.1)
-      activemodel (= 4.2.7.1)
-      activesupport (= 4.2.7.1)
+    activerecord (4.2.8)
+      activemodel (= 4.2.8)
+      activesupport (= 4.2.8)
       arel (~> 6.0)
-    activesupport (4.2.7.1)
+    activesupport (4.2.8)
       i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
@@ -40,7 +39,7 @@ GEM
       activesupport (>= 3.0.0)
     faker (1.7.3)
       i18n (~> 0.5)
-    ffi (1.9.17)
+    ffi (1.9.18)
     formatador (0.2.5)
     guard (2.14.1)
       formatador (>= 0.2.4)
@@ -60,14 +59,12 @@ GEM
       ffi
       guard (~> 2.0)
       spoon
-    hoodoo (1.12.4)
+    hoodoo (1.15.0)
       dalli (~> 2.7)
-      kgio (~> 2.9)
     httparty (0.14.0)
       multi_xml (>= 0.5.2)
-    i18n (0.8.0)
+    i18n (0.8.1)
     json (1.8.6)
-    kgio (2.11.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -100,7 +97,7 @@ GEM
       rack (>= 1.0)
       rack-test (>= 0.5)
     rake (10.5.0)
-    raygun4ruby (1.1.12)
+    raygun4ruby (1.2.1)
       httparty (> 0.13.7)
       json
       rack
@@ -134,7 +131,7 @@ GEM
     spoon (0.0.6)
       ffi
     thor (0.19.4)
-    thread_safe (0.3.5)
+    thread_safe (0.3.6)
     timecop (0.8.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
@@ -172,4 +169,4 @@ RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.14.3
+   1.14.5

--- a/bin/version_bump
+++ b/bin/version_bump
@@ -79,8 +79,15 @@ while getopts ":d" opt; do
   esac
 done
 
-#exit early if uncommited/pushed changes exist
-BRANCH_NAME=$(git name-rev --name-only HEAD)
+# https://git-scm.com/docs/git-symbolic-ref
+#
+# "Typically you would give HEAD as the <name> argument to see which branch
+# your working tree is on."
+#
+BRANCH_NAME=$(git symbolic-ref --short HEAD)
+
+# Exit early if uncommited/pushed changes exist.
+
 REMOTE_DIFFS=$(git log origin/$BRANCH_NAME..$BRANCH_NAME)
 LOCAL_DIFFS=$(git status -s)
 if [[ -n $LOCAL_DIFFS ]] || [[ -n $REMOTE_DIFFS ]]; then


### PR DESCRIPTION
We're actually not sure how the old code ever worked, though it did. According to Git's documentation, the new command should be much more predictable!