### PR TITLE
Airbrake 6->7 and related changes.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@
   #   gem 'alchemy-flux', '~> 1.2'
 
   gem 'rack',         '~> 2.0'
-  gem 'hoodoo',       '~> 2.0'
+  gem 'hoodoo',       '~> 2.2'
 
 # ActiveRecord and PostgreSQL
 
@@ -23,12 +23,12 @@
 
   gem 'newrelic_rpm', '~> 4.3'
   gem 'ddtrace',      '~> 0.9'
-  gem 'airbrake',     '~> 6.2'
-  gem 'raygun4ruby',  '~> 1.1'
+  gem 'airbrake',     '~> 7.1'
+  gem 'raygun4ruby',  '~> 2.6'
 
 # Maintenance
 
-  gem 'rake', '~> 10.3'
+  gem 'rake', '~> 12.2'
 
   # Service shell, similar to Rails console, but for any Rack application;
   # likewise a database console, similar to Rails dbconsole.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,16 +21,16 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    airbrake (6.3.0)
-      airbrake-ruby (~> 2.4)
-    airbrake-ruby (2.5.0)
+    airbrake (7.1.0)
+      airbrake-ruby (~> 2.5)
+    airbrake-ruby (2.5.1)
     arel (8.0.0)
     byebug (9.1.0)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
     dalli (2.7.6)
-    database_cleaner (1.6.1)
-    ddtrace (0.9.0)
+    database_cleaner (1.6.2)
+    ddtrace (0.9.2)
       msgpack
     diff-lcs (1.3)
     docile (1.1.5)
@@ -58,11 +58,11 @@ GEM
       ffi
       guard (~> 2.0)
       spoon
-    hoodoo (2.0.0)
+    hoodoo (2.2.0)
       dalli (~> 2.7)
     httparty (0.15.6)
       multi_xml (>= 0.5.2)
-    i18n (0.9.0)
+    i18n (0.9.1)
       concurrent-ruby (~> 1.0)
     json (1.8.6)
     listen (3.1.5)
@@ -95,8 +95,9 @@ GEM
     racksh (1.0.0)
       rack (>= 1.0)
       rack-test (>= 0.5)
-    rake (10.5.0)
-    raygun4ruby (1.5.0)
+    rake (12.2.1)
+    raygun4ruby (2.6.0)
+      concurrent-ruby
       httparty (> 0.13.7)
       json
       rack
@@ -131,7 +132,7 @@ GEM
     thor (0.20.0)
     thread_safe (0.3.6)
     timecop (0.9.1)
-    tzinfo (1.2.3)
+    tzinfo (1.2.4)
       thread_safe (~> 0.1)
 
 PLATFORMS
@@ -140,7 +141,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord (~> 5.1)
   activesupport (~> 5.1)
-  airbrake (~> 6.2)
+  airbrake (~> 7.1)
   byebug
   database_cleaner (~> 1.3)
   ddtrace (~> 0.9)
@@ -148,7 +149,7 @@ DEPENDENCIES
   faker (~> 1.4)
   guard-rspec
   guard-shotgun
-  hoodoo (~> 2.0)
+  hoodoo (~> 2.2)
   newrelic_rpm (~> 4.3)
   pg (~> 0.21)
   pry-byebug
@@ -156,8 +157,8 @@ DEPENDENCIES
   rack-test (~> 0.6)
   rackdb (~> 2.0)
   racksh (~> 1.0)
-  rake (~> 10.3)
-  raygun4ruby (~> 1.1)
+  rake (~> 12.2)
+  raygun4ruby (~> 2.6)
   rspec (~> 3.1)
   sdoc!
   simplecov-rcov (~> 0.2)

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,13 +1,17 @@
 # To enable Airbrake support, fill in the Airbrake project ID and key for
 # the Airbrake project of your choice and uncomment the code below.
 
-# require 'airbrake'
+# unless Service.config.env.test? || Service.config.env.development?
 #
-# Airbrake.configure do | config |
-#   config.project_id  = 'YOUR_AIRBRAKE_PROJECT_ID'
-#   config.project_key = 'YOUR_AIRBRAKE_PROJECT_KEY'
+#   require 'airbrake'
+#
+#   Airbrake.configure do | config |
+#     config.project_id  = 'YOUR_AIRBRAKE_PROJECT_ID'
+#     config.project_key = 'YOUR_AIRBRAKE_PROJECT_KEY'
+#   end
+#
+#   Hoodoo::Services::Middleware::ExceptionReporting.add(
+#     Hoodoo::Services::Middleware::ExceptionReporting::AirbrakeReporter
+#   )
+#
 # end
-#
-# Hoodoo::Services::Middleware::ExceptionReporting.add(
-#   Hoodoo::Services::Middleware::ExceptionReporting::AirbrakeReporter
-# ) unless Service.config.env.test? || Service.config.env.development?

--- a/config/initializers/raygun.rb
+++ b/config/initializers/raygun.rb
@@ -1,12 +1,16 @@
 # To enable Raygun support, fill in the Raygun API key and uncomment
 # the code below.
 
-# require 'raygun4ruby'
+# unless Service.config.env.test? || Service.config.env.development?
 #
-# Raygun.setup do | config |
-#   config.api_key = 'YOUR_RAYGUN_API_KEY'
+#   require 'raygun4ruby'
+#
+#   Raygun.setup do | config |
+#     config.api_key = 'YOUR_RAYGUN_API_KEY'
+#   end
+#
+#   Hoodoo::Services::Middleware::ExceptionReporting.add(
+#     Hoodoo::Services::Middleware::ExceptionReporting::RaygunReporter
+#   )
+#
 # end
-#
-# Hoodoo::Services::Middleware::ExceptionReporting.add(
-#   Hoodoo::Services::Middleware::ExceptionReporting::RaygunReporter
-# ) unless Service.config.env.test? || Service.config.env.development?


### PR DESCRIPTION
Maintenance 'bundle update' included. Initialiser approach changed to ensure
Airbrake is not included in environments where it is not wanted. Same thing
used for Raygun as defensive coding, though it is unnecessary right now.