### PR TITLE
Fix Datadog config file service name for 'hoodoo' regexp

### DIFF
--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -17,7 +17,7 @@
 #            port:     ENV[ 'DD_AGENT_PORT_8126_TCP_PORT' ]
 #
 #   c.use :rack, distributed_tracing: true,
-#                service_name:        'your_service_name'
+#                service_name:        'service_shell'
 #
 #   # Examples below are optional. If you use Net/HTTP to call out to external
 #   # services, or for inter-resource calls on a non-AMQP deployment, keep the


### PR DESCRIPTION
Oops! :-O

Hoodoo replaces "service_shell" when it clones the repo to create a new service, using the name given to it on the CLI.