### PR TITLE
Rakefile rationalisation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,6 +9,7 @@ require 'yaml'
 require 'erb'
 require 'active_record'
 require 'active_support/core_ext/hash/indifferent_access'
+require 'sdoc'
 require 'rdoc/task'
 
 include ActiveRecord::Tasks
@@ -90,11 +91,10 @@ namespace :g do
 end
 
 Rake::RDocTask.new do | rd |
-  require 'sdoc'
-
   rd.rdoc_files.include( 'README.md', 'service/**/*.rb', 'lib/**/*.rb' )
-  rd.rdoc_dir = 'docs/rdoc'
-  rd.title = 'Platform Service: Generic'
-  rd.main = 'README.md'
-  rd.options << '--format=sdoc'
+
+  rd.rdoc_dir  = 'docs/rdoc'
+  rd.title     = 'Platform Service: Generic'
+  rd.main      = 'README.md'
+  rd.generator = 'sdoc'
 end


### PR DESCRIPTION
Previously a `require` line was removed as the `Gemfile` didn't always include a relevant gem - it was in a development/test only group. Now, the `Gemfile` always includes `sdoc`, so the Rakefile can be simplified and tidied up a bit here.