### PR TITLE
DS-4652  Automated Monthly Patches - Jun24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change log
 
+## 1.0.8
+
+Automated Monthly Patching Jun24
+- Gems updated:
+  - timecop 0.9.9 (was 0.9.8)
+  - i18n 1.14.5 (was 1.14.4)
+  - activesupport 7.1.3.3 (was 7.1.3.2)
+  - activemodel 7.1.3.3 (was 7.1.3.2)
+  - activerecord 7.1.3.3 (was 7.1.3.2)
+
 ## 1.0.7
 
 - Moved from Travis CI to Github Actions [TO-7516](https://loyaltynz.atlassian.net/browse/TO-7516)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,13 +9,13 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (7.1.3.2)
-      activesupport (= 7.1.3.2)
-    activerecord (7.1.3.2)
-      activemodel (= 7.1.3.2)
-      activesupport (= 7.1.3.2)
+    activemodel (7.1.3.3)
+      activesupport (= 7.1.3.3)
+    activerecord (7.1.3.3)
+      activemodel (= 7.1.3.3)
+      activesupport (= 7.1.3.3)
       timeout (>= 0.4.0)
-    activesupport (7.1.3.2)
+    activesupport (7.1.3.3)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -84,7 +84,7 @@ GEM
       drb
       mutex_m
       rack
-    i18n (1.14.4)
+    i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     libdatadog (7.0.0.1.0)
     libddwaf (1.14.0.0.0)
@@ -149,7 +149,7 @@ GEM
       ffi
     stringio (3.0.9)
     thor (1.2.2)
-    timecop (0.9.8)
+    timecop (0.9.9)
     timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)


### PR DESCRIPTION
# Automated Monthly Patches
**Base Image:** docker.loyaltydevops.co.nz/service_base_ruby:3.3.0
**Command used:** # bundle update --patch
**Jenkins build:** https://jenkins.loyaltydevops.co.nz/job/TechOps/job/cron-jobs/job/MonthlyPatching/job/bundle_update/1354/



## Changes:
- timecop 0.9.9 (was 0.9.8)
- i18n 1.14.5 (was 1.14.4)
- activesupport 7.1.3.3 (was 7.1.3.2)
- activemodel 7.1.3.3 (was 7.1.3.2)
- activerecord 7.1.3.3 (was 7.1.3.2)
