### PR TITLE
DS-4791  Automated Monthly Patches - Jun24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change log
 
+## 1.0.9
+
+Automated Monthly Patching Jun24
+- Gems updated:
+  - timecop 0.9.10 (was 0.9.9)
+  - ddtrace 1.23.2 (was 1.23.0) with native extensions
+  - activesupport 7.1.3.4 (was 7.1.3.3)
+  - activemodel 7.1.3.4 (was 7.1.3.3)
+  - activerecord 7.1.3.4 (was 7.1.3.3)
+
 ## 1.0.8
 
 Automated Monthly Patching Jun24

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,13 +9,13 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (7.1.3.3)
-      activesupport (= 7.1.3.3)
-    activerecord (7.1.3.3)
-      activemodel (= 7.1.3.3)
-      activesupport (= 7.1.3.3)
+    activemodel (7.1.3.4)
+      activesupport (= 7.1.3.4)
+    activerecord (7.1.3.4)
+      activemodel (= 7.1.3.4)
+      activesupport (= 7.1.3.4)
       timeout (>= 0.4.0)
-    activesupport (7.1.3.3)
+    activesupport (7.1.3.4)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -43,7 +43,7 @@ GEM
     database_cleaner-core (2.0.1)
     datadog-ci (0.8.3)
       msgpack
-    ddtrace (1.23.0)
+    ddtrace (1.23.2)
       datadog-ci (~> 0.8.1)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 7.0.0.1.0)
@@ -149,7 +149,7 @@ GEM
       ffi
     stringio (3.0.9)
     thor (1.2.2)
-    timecop (0.9.9)
+    timecop (0.9.10)
     timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)


### PR DESCRIPTION
# Automated Monthly Patches
**Base Image:** docker.loyaltydevops.co.nz/service_base_ruby:3.3.0
**Command used:** # bundle update --patch
**Jenkins build:** https://jenkins.loyaltydevops.co.nz/job/TechOps/job/cron-jobs/job/MonthlyPatching/job/bundle_update/1418/



## Changes:
- timecop 0.9.10 (was 0.9.9)
- ddtrace 1.23.2 (was 1.23.0) with native extensions
- activesupport 7.1.3.4 (was 7.1.3.3)
- activemodel 7.1.3.4 (was 7.1.3.3)
- activerecord 7.1.3.4 (was 7.1.3.3)
